### PR TITLE
Fix the --fixers=-visibility option

### DIFF
--- a/phpspectools.sh
+++ b/phpspectools.sh
@@ -3,7 +3,7 @@
 function fixFormattingOnPhpSpecFiles ()
 {
     echo -ne "Fixing SPEC files... \033[36mcleaning\033[0m"\\r
-    bin/php-cs-fixer fix --fixers=-visibility spec --quiet
+    bin/php-cs-fixer fix --fixers=-visibility_required spec --quiet
     if [ $? -eq 0 ]; then
         echo -e "Fixing SPEC files... \033[32mclean   \033[0m"
         return 0


### PR DESCRIPTION
## Description

I get this error when I try to run the `ff` command (`spec` folder):
`The "--fixers" option does not exist.`

Related issue is #19
## Solution

Looks like the `visibility` option has been removed, but there is this one `visibility_required` that applies the same behaviour.
