### PR TITLE
Fix visibility fixer when run new release of 2.0.x@dev

### DIFF
--- a/phpspectools.sh
+++ b/phpspectools.sh
@@ -3,7 +3,15 @@
 function fixFormattingOnPhpSpecFiles ()
 {
     echo -ne "Fixing SPEC files... \033[36mcleaning\033[0m"\\r
-    bin/php-cs-fixer fix --fixers=-visibility_required spec --quiet
+
+    IS_VISIBILITY_REQUIRED=`bin/php-cs-fixer help fix | grep visibility_required | wc -l`
+
+    if [ $IS_VISIBILITY_REQUIRED -eq 0 ]; then
+        bin/php-cs-fixer fix --fixers=-visibility spec --quiet
+    else
+        bin/php-cs-fixer fix --rules=-visibility_required spec --quiet
+    fi
+
     if [ $? -eq 0 ]; then
         echo -e "Fixing SPEC files... \033[32mclean   \033[0m"
         return 0

--- a/phpspectools.sh
+++ b/phpspectools.sh
@@ -3,7 +3,7 @@
 function fixFormattingOnPhpSpecFiles ()
 {
     echo -ne "Fixing SPEC files... \033[36mcleaning\033[0m"\\r
-    bin/php-cs-fixer fix --fixers=-visibility spec --quiet
+    bin/php-cs-fixer fix --fixers=-visibility_required spec --quiet
     if [ $? -eq 0 ]; then
         echo -e "Fixing SPEC files... \033[32mclean   \033[0m"
         return 0


### PR DESCRIPTION
## Description

I get this error when I try to run the `ff` command (`spec` folder):
`The "--fixers" option does not exist.`

Related issue is #19
## Solution

Looks like the `--fixers=-visibility` option has been removed.
However, there is a new one `--rules=-visibility_required` that applies the same behaviour.
