### PR TITLE
Prevent Composer self-update

### DIFF
--- a/symfonytools.sh
+++ b/symfonytools.sh
@@ -31,7 +31,7 @@ if [ -n "$ENABLE_ALIAS" ] && [ "$ENABLE_ALIAS" = true ]; then
             fi
         fi
 
-        php composer.phar self-update > /dev/null 2>&1
+        #php composer.phar self-update > /dev/null 2>&1
 
         php composer.phar "$@"
 


### PR DESCRIPTION
Current version 1.3.2 is causing me a problem on Linux environments, due after self-upgrade to this version I was not able to install and process all `symfony-scripts` that my `composer.json` file has to run once packages are downloaded.

After downgrade to another version (thanks to this page https://github.com/composer/composer/releases) everything worked as usual